### PR TITLE
Add default port for mssql 1433

### DIFF
--- a/datacoco_db/mssql_tools.py
+++ b/datacoco_db/mssql_tools.py
@@ -37,7 +37,7 @@ class MSSQLInteraction:
     """
 
     def __init__(
-        self, dbname=None, host=None, user=None, password=None, port=None
+        self, dbname=None, host=None, user=None, password=None, port=1433
     ):
         if not dbname or not host or not user or not port or password is None:
             raise RuntimeError("%s request all __init__ arguments" % __name__)

--- a/tests/unit/test_mssql_tools.py
+++ b/tests/unit/test_mssql_tools.py
@@ -13,6 +13,15 @@ class TestMSSQLInteraction(unittest.TestCase):
             password="password",
             port="3306",
         )
+
+        testCls = MSSQLInteraction(
+            host="host",
+            dbname="db_name",
+            user="user",
+            password="password"
+        )  # Default port test
+
+
         testCls.cur = MagicMock()
         testCls.con = MagicMock()
         testCls.exec_sql(


### PR DESCRIPTION

## Changes

- Add default port for mssql - 1433

## Ticket
- https://equinoxfitness.atlassian.net/browse/DATPLAT-1511


### How Has This Been Tested?

_Example:_
1. Checkout this branch

1. Switch to virtual environment

1. Run mssql unit test
- [ ] Verify that the test passed

